### PR TITLE
Add offline_access scope to OIDC authorization request

### DIFF
--- a/src/data_commons_search/auth.py
+++ b/src/data_commons_search/auth.py
@@ -373,7 +373,7 @@ async def auth_login(request: Request, redirect: str | None = None) -> RedirectR
     params = {
         "client_id": settings.oidc_client_id,
         "response_type": "code",
-        "scope": "openid email profile voperson_id",  # TODO: offline_access
+        "scope": "openid email profile voperson_id offline_access",
         "redirect_uri": _callback_url(request),
         "state": state,
         "code_challenge": code_challenge,


### PR DESCRIPTION
This pull request makes a small update to the authentication logic by expanding the OAuth scopes requested during login.

* The `scope` parameter in the `auth_login` function in `src/data_commons_search/auth.py` now includes `offline_access`, which allows the application to request refresh tokens for long-lived sessions.