### PR TITLE
Enable root_path configuration for reverse proxy support

### DIFF
--- a/src/data_commons_search/config.py
+++ b/src/data_commons_search/config.py
@@ -11,8 +11,8 @@ class Settings(BaseSettings):
     # Server settings
     server_port: int = 8000
     server_host: str = "0.0.0.0"  # noqa: S104
-    # # Mount prefix when served behind a reverse proxy (e.g. "/api/search")
-    # root_path: str = ""
+    # Mount prefix when served behind a reverse proxy (e.g. "/api/search"). Empty for local dev.
+    root_path: str = ""
     cors_enabled: bool = True
     rate_limiting_enabled: bool = True
     # Set to False for local HTTP dev (browsers drop Secure cookies over plain HTTP). Keep True in prod.

--- a/src/data_commons_search/main.py
+++ b/src/data_commons_search/main.py
@@ -103,7 +103,7 @@ app = FastAPI(
     description="A server for the [EOSC Data Commons project](https://eosc.eu/horizon-europe-projects/eosc-data-commons/) MatchMaker service, providing natural language search over open-access datasets. It exposes an HTTP POST endpoint and supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) to help users discover datasets and tools via a Large Language Model-assisted search.",
     version="1.0.0",
     lifespan=lifespan,
-    # root_path=settings.root_path,
+    root_path=settings.root_path,
 )
 
 # Mount the MCP server with optional OAuth: a valid EGI bearer token is decoded and exposed to tools, but auth is NOT required


### PR DESCRIPTION
This pull request updates the server configuration and initialization to support specifying a root path for deployment behind a reverse proxy. The main changes include enabling the `root_path` setting in the configuration and ensuring it is used when initializing the FastAPI application.

**Server configuration and deployment:**

* Enabled the `root_path` setting in `Settings` to allow specifying a mount prefix when serving behind a reverse proxy, with an empty default for local development (`src/data_commons_search/config.py`).
* Updated the FastAPI app initialization to use the configured `root_path`, ensuring correct URL routing when deployed with a mount prefix (`src/data_commons_search/main.py`)