### PR TITLE
Update Dockerfile to exclude dev dependencies and adjust PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 WORKDIR /app
 COPY . /app/
 
-RUN uv sync --frozen --extra agent
+RUN uv sync --frozen --no-dev --extra agent
 
 ENV SERVER_PORT=8000
 ENV SERVER_HOST='0.0.0.0'
@@ -12,9 +12,10 @@ ENV SERVER_HOST='0.0.0.0'
 ENV LOG_JSON='true'
 ENV PYTHONUNBUFFERED='1'
 ENV WORKERS=6
+ENV PATH="/app/.venv/bin:$PATH"
 
 # # For proper resolution in prod at https://matchmaker.eosc-data-commons.eu/api/search/docs
 # ENV ROOT_PATH=/api/search
 
 EXPOSE 8000
-ENTRYPOINT ["sh", "-c", "uv run uvicorn src.data_commons_search.main:app --host $SERVER_HOST --port $SERVER_PORT --workers $WORKERS"]
+ENTRYPOINT ["sh", "-c", "uvicorn src.data_commons_search.main:app --host $SERVER_HOST --port $SERVER_PORT --workers $WORKERS"]


### PR DESCRIPTION
This pull request makes a few updates to the `Dockerfile` to optimize the production image and environment setup. The most notable changes involve modifying dependency installation to exclude development packages, updating the `PATH` to include the virtual environment, and simplifying the entrypoint command.

**Dockerfile improvements:**

* Changed the `uv sync` command to use `--no-dev`, ensuring that only production dependencies (excluding development packages) are installed.
* Added the virtual environment's `bin` directory to the `PATH` by setting `ENV PATH="/app/.venv/bin:$PATH"`, which ensures that executables from the virtual environment are accessible.
* Updated the `ENTRYPOINT` to call `uvicorn` directly, removing the redundant `uv run` wrapper for a simpler and more standard container startup.…ration