### PR TITLE
Implement timeouts for LLM generation and fix SwissUbase stats display

### DIFF
--- a/src/data_commons_search/main.py
+++ b/src/data_commons_search/main.py
@@ -1,5 +1,6 @@
 """HTTP API to deploy the EOSC Data Commons search agent."""
 
+import asyncio
 import contextlib
 import json
 import time
@@ -404,6 +405,14 @@ class ConversationBuilder:
 
 MAX_AGENT_ITERATIONS = 8
 
+# Upper bounds on how long a single LLM generation / tool call may run before we
+# give up. Without these a hung provider or MCP tool leaves the SSE stream open
+# forever with nothing sent; on timeout the TimeoutError propagates to the
+# stream's error handler, which emits a terminal RUN_ERROR the client renders
+# (a single tool timeout instead degrades to a tool-error the agent reacts to).
+LLM_STREAM_TIMEOUT_S = 60.0
+TOOL_CALL_TIMEOUT_S = 30.0
+
 
 async def stream_chat_response(
     search_input: AgentInput, user: UserInfo | None = None, access_token: str | None = None
@@ -457,7 +466,21 @@ async def stream_chat_response(
                     start_time = get_timestamp()
                     # Hide <think>...</think> reasoning unless the frontend opts in via settings
                     stripper = None if settings.stream_thinking else ThinkStripper()
-                    async for chunk in llm_with_tools.astream(lc_msgs):
+                    # Bound the whole generation with a deadline: each chunk must
+                    # arrive before it, otherwise a stalled provider would hold the
+                    # stream open forever.
+                    # (asyncio.timeout is 3.11+).
+                    loop = asyncio.get_running_loop()
+                    deadline = loop.time() + LLM_STREAM_TIMEOUT_S
+                    stream = llm_with_tools.astream(lc_msgs)
+                    while True:
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            raise TimeoutError("LLM generation timed out")
+                        try:
+                            chunk = await asyncio.wait_for(anext(stream), remaining)
+                        except StopAsyncIteration:
+                            break
                         if not isinstance(chunk, AIMessageChunk):
                             continue
                         accumulated = chunk if accumulated is None else accumulated + chunk
@@ -517,7 +540,9 @@ async def stream_chat_response(
                             yield _chunk
 
                         try:
-                            tool_call_res = await session.call_tool(tool_call_name, tool_call_args)
+                            tool_call_res = await asyncio.wait_for(
+                                session.call_tool(tool_call_name, tool_call_args), TOOL_CALL_TIMEOUT_S
+                            )
                         except Exception as exc:
                             logger.error(f"Tool call '{tool_call_name}' failed: {exc}")
                             err_text = f"Error calling tool {tool_call_name}: {exc}"
@@ -536,8 +561,11 @@ async def stream_chat_response(
                             rerank_id = f"rerank_{tool_call_id}"
                             for _chunk in conv.start_tool_call(rerank_id, "rerank_results", tool_call_args, msg_id):
                                 yield _chunk
-                            ranked = await rerank_search_results(
-                                search_input.model, [langfuse_handler], lc_msgs, search_results, token_usage
+                            ranked = await asyncio.wait_for(
+                                rerank_search_results(
+                                    search_input.model, [langfuse_handler], lc_msgs, search_results, token_usage
+                                ),
+                                LLM_STREAM_TIMEOUT_S,
                             )
                             ranked_dump = ranked.model_dump(by_alias=True)
                             for _chunk in conv.end_tool_call(

--- a/src/data_commons_search/stats.json
+++ b/src/data_commons_search/stats.json
@@ -299,7 +299,7 @@
       "top_subjects": []
     },
     {
-      "code": "SWISS",
+      "code": "SWISSUbase",
       "name": "SwissUbase",
       "record_count": 2167,
       "datasets": 2167,

--- a/src/data_commons_search/stats.py
+++ b/src/data_commons_search/stats.py
@@ -22,6 +22,20 @@ from data_commons_search.utils import logger
 # Pre-computed stats file, shipped with the package (see module docstring).
 STATS_FILE = Path(__file__).parent / "stats.json"
 
+# The upstream `repositories.code` value is used verbatim as the short display label for each
+# repository (e.g. on the landing-page "Datasets per repository" chart). A few of those codes are
+# stale/abbreviated in the source table; override them here so /stats reports each repository's
+# canonical short name. SwissUbase's code, for instance, is stored as "SWISS" — which is what users
+# saw mislabelled on the chart.
+REPOSITORY_CODE_OVERRIDES = {
+    "SWISS": "SWISSUbase",
+}
+
+
+def _display_code(code: str) -> str:
+    """Map an upstream repository code to its canonical short display code (identity if none)."""
+    return REPOSITORY_CODE_OVERRIDES.get(code, code)
+
 
 # Records count + dataset count per repository. LEFT JOIN so repos with zero harvested
 # records still appear (record_count = 0 = not yet harvested).
@@ -90,7 +104,7 @@ def compute_stats() -> DbStats:
 
     repositories = [
         RepositoryStats(
-            code=row["code"],
+            code=_display_code(row["code"]),
             name=row["name"],
             record_count=row["record_count"],
             datasets=row["datasets"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 from typing import Any
 
@@ -5,8 +7,9 @@ import httpx
 import pytest
 from ag_ui.core import RunStartedEvent
 
+from data_commons_search import main
 from data_commons_search.config import settings
-from data_commons_search.models import SummarizedSearchResponse
+from data_commons_search.models import AgentInput, SummarizedSearchResponse
 from tests.benchmark import TestItem, test_items
 
 # When running the tests, ensure the server is running on port 8000
@@ -136,6 +139,47 @@ def test_app(test_item: TestItem, llm_model: str) -> None:
 #     for hit in dummy_search_hits:
 #         print(f"Hit {hit.id} has file extensions: {hit.file_extensions}")
 #         assert hit.file_extensions and len(hit.file_extensions) >= 1
+
+
+class _HangingLLM:
+    """A model whose stream never yields, to simulate a stalled provider."""
+
+    async def astream(self, _msgs: Any):
+        await asyncio.sleep(30)
+        yield  # pragma: no cover - never reached before the timeout fires
+
+
+class _FakeMCPClient:
+    async def get_tools(self) -> list[Any]:
+        return []
+
+    @contextlib.asynccontextmanager
+    async def session(self, _name: str):
+        yield object()
+
+
+async def test_stream_emits_run_error_on_llm_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stalled LLM generation must terminate the stream with a RUN_ERROR event."""
+    # Shrink the timeout so the stalled stream trips it immediately.
+    monkeypatch.setattr(main, "LLM_STREAM_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(main, "build_mcp_client", lambda *_a, **_k: _FakeMCPClient())
+    monkeypatch.setattr(main, "load_chat_model_with_fallback", lambda *_a, **_k: (_HangingLLM(), "fake-model"))
+    monkeypatch.setattr(main, "propagate_attributes", lambda *_a, **_k: contextlib.nullcontext())
+    monkeypatch.setattr(main, "LangfuseCallbackHandler", lambda *_a, **_k: object())
+    monkeypatch.setattr(main.langfuse, "start_as_current_observation", lambda *_a, **_k: contextlib.nullcontext())
+    monkeypatch.setattr(main.langfuse, "update_current_span", lambda *_a, **_k: None)
+
+    search_input = AgentInput.model_validate(
+        {
+            "items": [{"type": "message", "role": "user", "content": [{"text": "ocean data"}]}],
+            "model": "fake-model",
+        }
+    )
+
+    events = [chunk async for chunk in main.stream_chat_response(search_input, user=None, access_token=None)]
+    joined = "".join(events)
+    assert "RUN_STARTED" in joined
+    assert "RUN_ERROR" in joined
 
 
 def process_stream(resp: httpx.Response) -> list[Any]:


### PR DESCRIPTION
This pull request introduces timeouts to prevent indefinite hangs during LLM generation and tool calls, ensures repository codes are displayed correctly in statistics, and adds a test to verify proper timeout handling. The most important changes are summarized below.

**Timeouts for LLM and Tool Calls**

* Added upper bounds for LLM generation (`LLM_STREAM_TIMEOUT_S`) and tool call duration (`TOOL_CALL_TIMEOUT_S`) in `main.py`, ensuring that a hung provider or tool does not leave the SSE stream open indefinitely. LLM generations are now wrapped with a timeout, and tool calls are also time-bounded. [[1]](diffhunk://#diff-155fcd94ac285381d84203000a30893725b9aafeabea5b6d2821a3ae10192362R3) [[2]](diffhunk://#diff-155fcd94ac285381d84203000a30893725b9aafeabea5b6d2821a3ae10192362R408-R415) [[3]](diffhunk://#diff-155fcd94ac285381d84203000a30893725b9aafeabea5b6d2821a3ae10192362L460-R483) [[4]](diffhunk://#diff-155fcd94ac285381d84203000a30893725b9aafeabea5b6d2821a3ae10192362L520-R545) [[5]](diffhunk://#diff-155fcd94ac285381d84203000a30893725b9aafeabea5b6d2821a3ae10192362L539-R568)

**Repository Code Display Fixes**

* Introduced the `REPOSITORY_CODE_OVERRIDES` mapping and `_display_code` function in `stats.py` to override and display canonical repository codes (e.g., "SWISS" is now shown as "SWISSUbase" in statistics). Updated the statistics computation to use the display code. [[1]](diffhunk://#diff-de425551f7d83ce76b1731872f94ea386555fd929e054565bb7bdee34856873cR25-R38) [[2]](diffhunk://#diff-de425551f7d83ce76b1731872f94ea386555fd929e054565bb7bdee34856873cL93-R107)
* Updated `stats.json` to reflect the corrected repository code for SwissUbase.

**Testing for Timeout Handling**

* Added a test in `test_server.py` that simulates a stalled LLM provider to ensure the SSE stream terminates with a `RUN_ERROR` event when the timeout is exceeded. [[1]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acR1-R12) [[2]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acR144-R184)