### PR TITLE
Blablador

### DIFF
--- a/src/data_commons_search/config.py
+++ b/src/data_commons_search/config.py
@@ -64,13 +64,14 @@ class Settings(BaseSettings):
     # reranker_url: str = "https://llm.ai.e-infra.cz/v1/rerank"
 
     # LLM providers API keys
-    default_llm_model: str = "cesnet/agentic"
+    default_llm_model: str = "blablador/alias-fast"
     # default_llm_model: str = "openrouter/qwen/qwen3-coder-flash"
     # default_llm_model: str = "mistralai/mistral-medium-latest"
     # Model used as a fallback when the primary provider errors (rate-limit, invalid
     # model name, auth error, outage, etc.). Set to "" to disable the fallback.
     fallback_llm_model: str = "mistralai/mistral-medium-latest"
     cesnet_api_key: str = ""
+    blablador_api_key: str = ""
     fedllm_api_key: str = ""
     openrouter_api_key: str = ""
     mistral_api_key: str = ""

--- a/src/data_commons_search/config.py
+++ b/src/data_commons_search/config.py
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
     # reranker_url: str = "https://llm.ai.e-infra.cz/v1/rerank"
 
     # LLM providers API keys
-    default_llm_model: str = "blablador/alias-fast"
+    default_llm_model: str = "cesnet/agentic"
     # default_llm_model: str = "openrouter/qwen/qwen3-coder-flash"
     # default_llm_model: str = "mistralai/mistral-medium-latest"
     # Model used as a fallback when the primary provider errors (rate-limit, invalid

--- a/src/data_commons_search/utils.py
+++ b/src/data_commons_search/utils.py
@@ -79,6 +79,16 @@ def load_chat_model(model: str, callbacks: Callbacks = None) -> BaseChatModel:
     """
     provider, model_name = model.split("/", maxsplit=1)
 
+    if provider == "blablador":
+        return ChatOpenAI(
+            base_url="https://api.blablador.fz-juelich.de/v1",
+            model=model_name,
+            api_key=SecretStr(settings.blablador_api_key),
+            stream_usage=True,
+            callbacks=callbacks,
+            # max_completion_tokens=settings.llm_max_tokens, # NOTE: breaks litellm
+        )
+
     if provider == "cesnet" or provider == "einfracz":
         # LiteLLM API https://llm.ai.e-infra.cz
         return ChatOpenAI(


### PR DESCRIPTION
Support for [Blablador](https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access/) as a provider, relevant for users at German Helmholtz centers and in particuar FZJ.

First commit contains a default setting with a model one can use to get started.